### PR TITLE
Remove locale from toLocaleDateString.

### DIFF
--- a/src/scripts/activity.js
+++ b/src/scripts/activity.js
@@ -49,7 +49,7 @@ class Activity {
         if (setting_restriction_list !== undefined && setting_restriction_list.length > 0) {
             var item = setting_restriction_list.find(o => isDomainEquals(extractHostname(o.domain), extractHostname(domain)));
             if (item !== undefined) {
-                var today = new Date().toLocaleDateString("en-US");
+                var today = new Date().toLocaleDateString();
                 var data = tab.days.find(x => x.date == today);
                 if (data !== undefined) {
                     var todayTimeUse = data.summary;
@@ -117,17 +117,17 @@ class Activity {
     }
 
     addTimeInterval(domain) {
-        var item = timeIntervalList.find(o => o.domain === domain && o.day == new Date().toLocaleDateString("en-US"));
+        var item = timeIntervalList.find(o => o.domain === domain && o.day == new Date().toLocaleDateString());
         if (item != undefined) {
-            if (item.day == new Date().toLocaleDateString("en-US"))
+            if (item.day == new Date().toLocaleDateString())
                 item.addInterval();
             else {
-                var newInterval = new TimeInterval(new Date().toLocaleDateString("en-US"), domain);
+                var newInterval = new TimeInterval(new Date().toLocaleDateString(), domain);
                 newInterval.addInterval();
                 timeIntervalList.push(newInterval);
             }
         } else {
-            var newInterval = new TimeInterval(new Date().toLocaleDateString("en-US"), domain);
+            var newInterval = new TimeInterval(new Date().toLocaleDateString(), domain);
             newInterval.addInterval();
             timeIntervalList.push(newInterval);
         }
@@ -135,7 +135,7 @@ class Activity {
 
     closeIntervalForCurrentTab() {
         if (currentTab !== '' && timeIntervalList != undefined) {
-            var item = timeIntervalList.find(o => o.domain === currentTab && o.day == new Date().toLocaleDateString("en-US"));
+            var item = timeIntervalList.find(o => o.domain === currentTab && o.day == new Date().toLocaleDateString());
             if (item != undefined)
                 item.closeInterval();
         }
@@ -146,7 +146,7 @@ class Activity {
         if (setting_notification_list !== undefined && setting_notification_list.length > 0) {
             var item = setting_notification_list.find(o => isDomainEquals(extractHostname(o.domain), extractHostname(domain)));
             if (item !== undefined) {
-                var today = new Date().toLocaleDateString("en-US");
+                var today = new Date().toLocaleDateString();
                 var data = tab.days.find(x => x.date == today);
                 if (data !== undefined) {
                     var todayTimeUse = data.summary;

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -80,7 +80,7 @@ function mainTRacker(activeUrl, tab, activeTab) {
     }
     if (setting_view_in_badge === true) {
         chrome.browserAction.setBadgeBackgroundColor({ color: '#1aa1434d' })
-        var today = new Date().toLocaleDateString("en-US");
+        var today = new Date().toLocaleDateString();
         var summary = tab.days.find(s => s.date === today).summary;
         chrome.browserAction.setBadgeText({
             tabId: activeTab.id,
@@ -296,7 +296,7 @@ function deleteTimeIntervalFromTabs() {
 }
 
 function deleteYesterdayTimeInterval() {
-    timeIntervalList = timeIntervalList.filter(x => x.day == new Date().toLocaleDateString("en-US"));
+    timeIntervalList = timeIntervalList.filter(x => x.day == new Date().toLocaleDateString());
 }
 
 function loadBlackList() {

--- a/src/scripts/tab.js
+++ b/src/scripts/tab.js
@@ -21,7 +21,7 @@ class Tab {
     incSummaryTime() {
         this.summaryTime += 1;
 
-        var today = new Date().toLocaleDateString("en-US");
+        var today = new Date().toLocaleDateString();
         var day = this.days.find(x => x.date == today);
         if (day === undefined) {
             this.addNewDay(today);
@@ -32,14 +32,14 @@ class Tab {
     }
 
     getTodayTime(){
-        var today = new Date().toLocaleDateString("en-US");
+        var today = new Date().toLocaleDateString();
         return this.days.find(x => x.date == today).summary;
     }
 
     incCounter(){
         this.counter +=1;
 
-        var today = new Date().toLocaleDateString("en-US");
+        var today = new Date().toLocaleDateString();
         var day = this.days.find(x => x.date == today);
         if (day === undefined) {
             this.addNewDay(today);

--- a/src/scripts/webact.js
+++ b/src/scripts/webact.js
@@ -7,7 +7,7 @@ var totalTime, averageTime;
 var tabsFromStorage;
 var targetTabs;
 var currentTypeOfList;
-var today = new Date().toLocaleDateString("en-US");
+var today = new Date().toLocaleDateString();
 var setting_range_days;
 var setting_dark_mode;
 var restrictionList;
@@ -421,15 +421,15 @@ function setStatData(array) {
         return a.total - b.total;
     });
 
-    stat.inActiveDay = new Date(arrayAscByTime[0].date).toLocaleDateString('ru-RU');
-    stat.activeDay = new Date(arrayAscByTime[arrayAscByTime.length - 1].date).toLocaleDateString('ru-RU');;
+    stat.inActiveDay = new Date(arrayAscByTime[0].date).toLocaleDateString();
+    stat.activeDay = new Date(arrayAscByTime[arrayAscByTime.length - 1].date).toLocaleDateString();
     stat.inActiveDayTime = arrayAscByTime[0].total;
     stat.activeDayTime = arrayAscByTime[arrayAscByTime.length - 1].total;
 
     //exclude current day from summary statistics 
     if (arrayAscByTimeWithoutCurrentDay.length > 0) {
-        stat.inActiveDayWithoutCurrentDay = new Date(arrayAscByTimeWithoutCurrentDay[0].date).toLocaleDateString('ru-RU');
-        stat.activeDayWithoutCurrentDay = new Date(arrayAscByTimeWithoutCurrentDay[arrayAscByTimeWithoutCurrentDay.length - 1].date).toLocaleDateString('ru-RU');
+        stat.inActiveDayWithoutCurrentDay = new Date(arrayAscByTimeWithoutCurrentDay[0].date).toLocaleDateString();
+        stat.activeDayWithoutCurrentDay = new Date(arrayAscByTimeWithoutCurrentDay[arrayAscByTimeWithoutCurrentDay.length - 1].date).toLocaleDateString();
         stat.inActiveDayTimeWithoutCurrentDay = arrayAscByTimeWithoutCurrentDay[0].total;
         stat.activeDayTimeWithoutCurrentDay = arrayAscByTimeWithoutCurrentDay[arrayAscByTimeWithoutCurrentDay.length - 1].total;
     }
@@ -438,7 +438,7 @@ function setStatData(array) {
         stat.inActiveDayWithoutCurrentDay = 'No data';
     }
 
-    stat.firstDay = new Date(array[0]).toLocaleDateString('ru-RU');;
+    stat.firstDay = new Date(array[0]).toLocaleDateString();
     stat.activeDays = array.length;
     stat.averageTime = Math.round(totalTime / array.length);
     stat.totalDays = daysBetween(array[0], array[array.length - 1]);
@@ -474,7 +474,7 @@ function getTabsByDays(tabs) {
             let second = end;
             var arr = [];
             for (let i = first; i <= second; i = new Date(i.setDate(i.getDate() + 1))) {
-                arr.push(new Date(i).toLocaleDateString("en-US"));
+                arr.push(new Date(i).toLocaleDateString());
             }
             return arr;
         };


### PR DESCRIPTION
Fixes #45, #46

Locale usage is inconsistent, removing the explicitly passed locale parameter will use the default locale:

>In basic use without specifying a locale, a formatted string in the default locale and with default options is returned.
>
> -- Source: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#using_tolocaledatestring)