### PR TITLE
URL parsing refactor to support paths

### DIFF
--- a/src/block.html
+++ b/src/block.html
@@ -8,6 +8,8 @@
    <script src="scripts/storage.js"></script>
    <script src="scripts/common.js"></script>
    <script src="scripts/block.js"></script>
+   <script src="scripts/restriction.js"></script>
+   <script src="scripts/url.js"></script>
 </head>
 
 <body>

--- a/src/index.html
+++ b/src/index.html
@@ -119,5 +119,8 @@
 <script src="scripts/chart/chart-core.js"></script>
 <script src="scripts/storage.js"></script>
 <script src="scripts/common.js"></script>
+<script src="scripts/timeInterval.js"></script>
+<script src="scripts/restriction.js"></script>
 <script src="scripts/ui.js"></script>
+<script src="scripts/url.js"></script>
 <script src="scripts/webact.js"></script>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,7 +38,8 @@
                         "scripts/tab.js", 
                         "scripts/timeInterval.js",
                         "scripts/background.js",
-                        "scripts/restriction.js"],
+                        "scripts/restriction.js",
+                        "scripts/url.js"],
             "persistent": false
         },
         "browser_action": {

--- a/src/options.html
+++ b/src/options.html
@@ -150,7 +150,8 @@
             <div id='restrictionsBlock' hidden>
                 <label>Access daily restrictions for websites: </label>
                 <div class="tooltip"><img src="/icons/information.svg" height="18" />
-                    <span class="tooltiptext">Set the maximum time allowed on the site per day. After this time, has elapsed the site will be blocked.</span>
+                    <span class="tooltiptext">Set the maximum time allowed on the site per day. After this time, has elapsed the site will be blocked. 
+                        Restrictions can be configured for specific paths on a site as well.</span>
                 </div>
                 <div class="margin-top-10">
                     <input type="text" class="label-with-list" placeholder="Enter site name..."
@@ -171,7 +172,7 @@
                 <label>List of sites with notifications: </label>
                 <div class="tooltip"><img src="/icons/information.svg" height="18" />
                     <span class="tooltiptext">Show notifications every time you spend a specified time interval on the
-                        site</span>
+                        site. Notifications can be configured for specific paths on a site as well.</span>
                 </div>
                 <div class="margin-top-10">
                     <input type="text" class="label-with-list" placeholder="Enter site name..." id='addNotifySiteLbl' />

--- a/src/options.html
+++ b/src/options.html
@@ -11,6 +11,7 @@
     <script src="scripts/storage.js"></script>
     <script src="scripts/settings.js"></script>
     <script src="scripts/restriction.js"></script>
+    <script src="scripts/url.js"></script>
     <script src="scripts/picker/jquery-3.3.1.min.js"></script>
     <script src="scripts/picker/clockpicker.min.js"></script>
 </head>

--- a/src/scripts/block.js
+++ b/src/scripts/block.js
@@ -6,16 +6,15 @@ var restrictionList = [];
 
 document.addEventListener("DOMContentLoaded", function () {
   var url = new URL(document.URL);
-  blockSiteUrl = url.searchParams.get("url");
-  document.getElementById("site").innerText = extractHostname(blockSiteUrl);
+  blockSiteUrl = new Url(url.searchParams.get("url"));
+  document.getElementById("site").innerText = blockSiteUrl;
 
   storage.getValue(STORAGE_RESTRICTION_LIST, function (items) {
-    restrictionList = items;
+    restrictionList = (items || []).map(item => new Restriction(item.url || item.domain, item.time));
     if (restrictionList === undefined) restrictionList = [];
-    var currentItem = restrictionList.find((x) =>
-      isDomainEquals(extractHostname(x.domain), extractHostname(blockSiteUrl))
-    );
+    var currentItem = restrictionList.find(x => x.url.isMatch(blockSiteUrl));
     if (currentItem !== undefined) {
+      document.getElementById("site").innerText = currentItem.url.toString();
       document.getElementById("limit").innerText =
         convertShortSummaryTimeToString(currentItem.time);
     }
@@ -38,7 +37,7 @@ document.addEventListener("DOMContentLoaded", function () {
           chrome.tabs.query(
             { currentWindow: true, active: true },
             function (tab) {
-              chrome.tabs.update(tab.id, { url: blockSiteUrl });
+              chrome.tabs.update(tab.id, { url: blockSiteUrl.href });
             }
           );
         });

--- a/src/scripts/chart/chart-core.js
+++ b/src/scripts/chart/chart-core.js
@@ -475,7 +475,7 @@ function drawIntervalChart(data) {
         })
         .attr("height", function (d) {
             var offset = getMinutesTo(d.interval) - getMinutesFrom(d.interval);
-            if (offset == 0) {
+            if (offset <= 0) {
                 var offsetSeconds = getSecondsTo(d.interval) - getSecondsFrom(d.interval);
                 if (offsetSeconds <= 3)
                     return 0;

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -64,10 +64,15 @@ function isEmpty(obj) {
 }
 
 function convertTimeToSummaryTime(time) {
+    var resultTimeValue = Number(time);
+    if (!isNaN(resultTimeValue)){
+        return resultTimeValue;
+    }
+
     var timeValue = time.split(':');
     var hour = timeValue[0];
     var min = timeValue[1];
-    var resultTimeValue = 0;
+    resultTimeValue = 0;
     if (hour > 0)
         resultTimeValue = hour * 3600;
     resultTimeValue += min * 60;
@@ -187,38 +192,6 @@ function getDateFromRange(range) {
         case 'month3':
             return 90;
     }
-}
-
-function isDomainEquals(first, second) {
-    if (first === second)
-        return true;
-    else {
-        var resultUrl = function(url) {
-            if (url.indexOf('www.') > -1)
-                return url.split('www.')[1];
-            return url;
-        };
-
-        if (resultUrl(first) === resultUrl(second))
-            return true;
-        else return false;
-    }
-}
-
-function extractHostname(url) {
-    var hostname;
-
-    if (url.indexOf("//") > -1) {
-        hostname = url.split('/')[2];
-    }
-    else {
-        hostname = url.split('/')[0];
-    }
-
-    hostname = hostname.split(':')[0];
-    hostname = hostname.split('?')[0];
-
-    return hostname;
 }
 
 function treatAsUTC(date) {

--- a/src/scripts/restriction.js
+++ b/src/scripts/restriction.js
@@ -1,15 +1,15 @@
 'use strict';
 
 class Restriction {
-    constructor(domain, time) {
-        this.domain = domain;
+    constructor(url, time) {
+        this.url = new Url(url);
         this.time = convertTimeToSummaryTime(time);
     }
 };
 
 class Notification{
-    constructor(domain, time) {
-        this.domain = domain;
+    constructor(url, time) {
+        this.url = new Url(url);
         this.time = convertTimeToSummaryTime(time);
     }
 };

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -116,22 +116,16 @@ function loadSettings() {
         let s = item;
     });
     storage.getValue(STORAGE_BLACK_LIST, function (items) {
-        if (items !== undefined)
-            blackList = items;
-        else blackList = [];
-        viewBlackList(items);
+        blackList = (items || []).map(item => new Url(item))
+        viewBlackList(blackList);
     });
     storage.getValue(STORAGE_RESTRICTION_LIST, function (items) {
-        restrictionList = items;
-        if (restrictionList === undefined)
-            restrictionList = [];
-        viewRestrictionList(items);
+        restrictionList = (items || []).map(item => new Restriction(item.url || item.domain, item.time));
+        viewRestrictionList(restrictionList);
     });
     storage.getValue(STORAGE_NOTIFICATION_LIST, function (items) {
-        notifyList = items;
-        if (notifyList === undefined)
-            notifyList = [];
-        viewNotificationList(items);
+        notifyList = (items || []).map(item => new Notification(item.url || item.domain, item.time));
+        viewNotificationList(notifyList);
     });
     storage.getValue(STORAGE_NOTIFICATION_MESSAGE, function (mess) {
         document.getElementById('notifyMessage').value = mess;
@@ -250,7 +244,7 @@ function viewNotificationList(items) {
 function viewRestrictionList(items) {
     if (items !== undefined) {
         for (var i = 0; i < items.length; i++) {
-            addDomainToEditableListBox(items[i], 'restrictionsList', actionEditSite, deleteRestrictionSite, updateItemFromResctrictoinList, updateRestrictionList);
+            addDomainToEditableListBox(items[i], 'restrictionsList', actionEditSite, deleteRestrictionSite, updateItemFromRestrictionList, updateRestrictionList);
         }
     }
 }
@@ -332,7 +326,7 @@ function viewNotify(elementName) {
 function actionAddRectrictionToList(newSite, newTime) {
     if (!isContainsRestrictionSite(newSite)) {
         var restriction = new Restriction(newSite, newTime);
-        addDomainToEditableListBox(restriction, 'restrictionsList', actionEditSite, deleteRestrictionSite, updateItemFromResctrictoinList, updateRestrictionList);
+        addDomainToEditableListBox(restriction, 'restrictionsList', actionEditSite, deleteRestrictionSite, updateItemFromRestrictionList, updateRestrictionList);
         if (restrictionList === undefined)
             restrictionList = [];
         restrictionList.push(restriction);
@@ -404,7 +398,7 @@ function addDomainToEditableListBox(entity, elementId, actionEdit, actionDelete,
     var domainLbl = document.createElement('input');
     domainLbl.type = 'text';
     domainLbl.classList.add('readonly-input', 'inline-block', 'element-item');
-    domainLbl.value = entity.domain;
+    domainLbl.value = entity.url.toString();
     domainLbl.readOnly = true;
     domainLbl.setAttribute('name', 'domain');
 
@@ -456,7 +450,7 @@ function deleteBlackSite(e) {
 function deleteRestrictionSite(e) {
     var targetElement = e.path[1];
     var itemValue = targetElement.querySelector("[name='domain']").value;
-    var item = restrictionList.find(x => x.domain == itemValue);
+    var item = restrictionList.find(x => x.url.isMatch(itemValue));
     restrictionList.splice(restrictionList.indexOf(item), 1);
     document.getElementById('restrictionsList').removeChild(targetElement);
     updateRestrictionList();
@@ -465,7 +459,7 @@ function deleteRestrictionSite(e) {
 function deleteNotificationSite(e) {
     var targetElement = e.path[1];
     var itemValue = targetElement.querySelector("[name='domain']").value;
-    var item = notifyList.find(x => x.domain == itemValue);
+    var item = notifyList.find(x => x.url.isMatch(itemValue));
     notifyList.splice(notifyList.indexOf(item), 1);
     document.getElementById('notifyList').removeChild(targetElement);
     updateNotificationList();
@@ -501,23 +495,23 @@ function actionEditSite(e, actionUpdateTimeFromList, actionUpdateList) {
 }
 
 function isContainsRestrictionSite(domain) {
-    return restrictionList.find(x => x.domain == domain) != undefined;
+    return restrictionList.find(x => x.url.isMatch(domain)) != undefined;
 }
 
 function isContainsNotificationSite(domain) {
-    return notifyList.find(x => x.domain == domain) != undefined;
+    return notifyList.find(x => x.url.isMatch(domain)) != undefined;
 }
 
 function isContainsBlackSite(domain) {
-    return blackList.find(x => x == domain) != undefined;
+    return blackList.find(x => x.isMatch(domain)) != undefined;
 }
 
-function updateItemFromResctrictoinList(domain, time) {
-    restrictionList.find(x => x.domain === domain).time = convertTimeToSummaryTime(time);
+function updateItemFromRestrictionList(domain, time) {
+    restrictionList.find(x => x.url.isMatch(domain)).time = convertTimeToSummaryTime(time);
 }
 
 function updateItemFromNotifyList(domain, time) {
-    notifyList.find(x => x.domain === domain).time = convertTimeToSummaryTime(time);
+    notifyList.find(x => x.url.isMatch(domain)).time = convertTimeToSummaryTime(time);
 }
 
 function updateBlackList() {

--- a/src/scripts/tab.js
+++ b/src/scripts/tab.js
@@ -2,7 +2,7 @@
 
 class Tab {
     constructor(url, favicon, days, summary, counter) {
-        this.url = url;
+        this.url = new Url(url);
         this.favicon = favicon;
         if (summary !== undefined)
             this.summaryTime = summary;

--- a/src/scripts/timeInterval.js
+++ b/src/scripts/timeInterval.js
@@ -1,8 +1,8 @@
 'use strict';
 
 class TimeInterval {
-    constructor(day, domain, intervals) {
-        this.domain = domain;
+    constructor(day, url, intervals) {
+        this.url = new Url(url);
         if (intervals != undefined)
             this.intervals = intervals;
         else this.intervals = [];

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -319,8 +319,8 @@ class UI {
 
     getDateRange() {
         return {
-            'from': new Date(document.getElementById('dateFrom').value),
-            'to': new Date(document.getElementById('dateTo').value)
+            'from': new Date(document.getElementById('dateFrom').value  + ' '),
+            'to': new Date(document.getElementById('dateTo').value  + ' ')
         };
     }
 

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -162,9 +162,10 @@ class UI {
 
     addLineToTableOfSite(tab, currentTab, summaryTime, typeOfList, counter, blockName) {
         var div = document.createElement('div');
+        var tabUrlString = tab.url.host;
         div.addEventListener('mouseenter', function() {
             if (document.getElementById('chart').innerHTML !== '') {
-                var item = document.getElementById(tab.url);
+                var item = document.getElementById(tabUrlString);
                 if (item !== null) {
                     item.dispatchEvent(new Event('mouseenter'));
                     item.classList.add('mouse-over');
@@ -176,7 +177,7 @@ class UI {
         });
         div.addEventListener('mouseout', function() {
             if (document.getElementById('chart').innerHTML !== '') {
-                var item = document.getElementById(tab.url);
+                var item = document.getElementById(tabUrlString);
                 if (item !== null) {
                     item.classList.remove('mouse-over');
                 } else document.getElementById('Others').classList.remove('mouse-over');
@@ -193,10 +194,10 @@ class UI {
         divForImg.classList.add('block-img');
         divForImg.appendChild(img);
 
-        var spanUrl = this.createElement('span', ['span-url'], tab.url);
-        spanUrl.setAttribute('href', 'https://' + tab.url);
+        var spanUrl = this.createElement('span', ['span-url'], tabUrlString);
+        spanUrl.setAttribute('href', 'https://' + tabUrlString);
 
-        if (tab.url == currentTab) {
+        if (tab.url.isMatch(currentTab)) {
             var divForImage = document.createElement('div');
             div.classList.add('span-active-url');
             var imgCurrentDomain = document.createElement('img');
@@ -212,7 +213,7 @@ class UI {
 
         if (typeOfList !== undefined && typeOfList === TypeListEnum.ToDay) {
             if (restrictionList !== undefined && restrictionList.length > 0) {
-                var item = restrictionList.find(x => isDomainEquals(x.domain, tab.url));
+                var item = restrictionList.find(x => x.url.isMatch(tab.url));
                 if (item !== undefined) {
                     var divLimit = this.createElement('div', ['tooltip', 'inline-block']);
                     var limitIcon = this.createElement('img', ['margin-left-5', 'tooltip']);

--- a/src/scripts/url.js
+++ b/src/scripts/url.js
@@ -1,0 +1,66 @@
+"use strict";
+
+class Url {
+  constructor(url) {
+    if (url instanceof URL) {
+      item = url;
+    } else if (typeof url === "string") {
+      if (url.indexOf("//") === -1) {
+        url = "http://" + url;
+      }
+    } else {
+      this.href = url.href;
+      this.host = url.host;
+      this.path = url.path;
+      return;
+    }
+
+    var item = new URL(url);
+
+    this.href = item.href;
+    this.host = item.hostname;
+    this.path = item.pathname === "/" ? "" : item.pathname;
+  }
+
+  isMatch(url) {
+    if (!url) {
+      return false;
+    }
+
+    try {
+      url = url instanceof Url ? url : new Url(url);
+    } catch {
+      return false;
+    }
+
+    return this.isHostMatch(url.host) && this.isPathMatch(url.path);
+  }
+
+  isHostMatch(host) {
+    if (host === this.host) {
+      return true;
+    }
+
+    var thisHostParts = this.host.split(".").reverse();
+
+    var hostParts = host.split(".").reverse();
+
+    var result = thisHostParts.every((part, i) => hostParts[i] === part);
+    
+    return result;
+  }
+
+  isPathMatch(path) {
+    var result = path === this.path || path.indexOf(this.path) === 0;
+
+    return result;
+  }
+
+  getId() {
+    return this.host + this.path.replace(/\//g, "-");
+  }
+
+  toString() {
+    return this.host + this.path;
+  }
+}

--- a/src/scripts/webact.js
+++ b/src/scripts/webact.js
@@ -163,9 +163,7 @@ function getDataFromStorageByDays() {
 }
 
 function getLimitsListFromStorageCallback(items) {
-    if (items !== undefined)
-        restrictionList = items;
-    else restrictionList = [];
+    restrictionList = (items || []).map(item => new Restriction(item.url, item.time));
 }
 
 function fillEmptyBlock() {
@@ -265,11 +263,12 @@ function getTabsForTimeChart(timeIntervals) {
         timeIntervals.forEach(function (data) {
             if (data.day == todayLocalDate()) {
                 data.intervals.forEach(function (interval) {
-                    resultArr.push({ 'domain': data.domain, 'interval': interval });
+                    resultArr.push({ 'domain': data.url.host, 'interval': interval });
                 });
             }
         });
     }
+
     return resultArr;
 }
 
@@ -283,7 +282,14 @@ function getTimeIntervalList() {
 }
 
 function drawTimeChart(items) {
-    ui.drawTimeChart(getTabsForTimeChart(items));
+    var timeIntervalList = [];
+    items = items || [];
+
+    for (var i = 0; i < items.length; i++) {
+        timeIntervalList.push(new TimeInterval(items[i].day, items[i].url || items[i].domain, items[i].intervals));
+    }
+
+    ui.drawTimeChart(getTabsForTimeChart(timeIntervalList));
 }
 
 function getTabsFromStorageForExpander(tabs) {
@@ -352,7 +358,7 @@ function getCurrentTab() {
 
 function addTabForChart(tabsForChart, url, time, counter) {
     tabsForChart.push({
-        'url': url,
+        'url': url.host,
         'percentage': getPercentageForChart(time),
         'summary': time,
         'visits': counter

--- a/src/style/settings.css
+++ b/src/style/settings.css
@@ -225,13 +225,13 @@ input[type="button"]:hover {
     background-color: #555;
     color: #fff;
     text-align: center;
-    padding: 5px 0;
+    padding: 5px;
     border-radius: 6px;
   
     /* Position the tooltip text */
     position: absolute;
     z-index: 1;
-    transform: translateX(-50%) translateY(-150%);
+    transform: translateX(-50%) translateY(-120%);
   
     /* Fade in tooltip */
     opacity: 0;


### PR DESCRIPTION
This update refactors URL parsing logic into a separate url class that can be used for comparing both the domain and the path. This allows for setting restrictions by path and domain. For example, one may want to set a restriction for a URL such as `bing.com/fun`, while still allowing unrestricted access to the rest of the `bing.com` domain.

![image](https://user-images.githubusercontent.com/1247613/136138354-aff723d7-1d3c-460a-86b3-b2aa74cf600d.png)

Adding a restriction for a domain will also restrict subdomain. For example, using the following restriction:
![image](https://user-images.githubusercontent.com/1247613/136138479-6b3d7091-4427-4875-88fc-68a1e128c2ae.png)

The block page will appear for subdomains as well:
![image](https://user-images.githubusercontent.com/1247613/136138798-3ca7aa43-3b4c-47b3-bea4-6d4f11502b28.png)

Also fixes a minor off-by-one date parsing issue on the date range.
Before: 
![image](https://user-images.githubusercontent.com/1247613/136139915-67f27aaa-883d-4d64-9192-5b000a39b72c.png)

After:
![image](https://user-images.githubusercontent.com/1247613/136139836-107921da-11fb-4114-983a-d647b729d510.png)

Open for discussion on this PR, please let me know if there are any issues.

Closes #21, without requiring an asterisk. Also opens up the door for some other feature requests to be implemented more easily (#3, #25, #32, #43, #47).

Thanks in advance for your consideration!

Travis
