### PR TITLE
Fix race condition with setting current tab

### DIFF
--- a/src/scripts/activity.js
+++ b/src/scripts/activity.js
@@ -114,11 +114,6 @@ class Activity {
         this.addTimeInterval(domain);
     }
 
-    clearCurrentActiveTab() {
-        this.closeIntervalForCurrentTab();
-        currentTab = null;
-    }
-
     addTimeInterval(domain) {
         var item = timeIntervalList.find(o => o.url.isMatch(domain) && o.day == todayLocalDate());
         if (item != undefined) {
@@ -136,13 +131,16 @@ class Activity {
         }
     }
 
-    closeIntervalForCurrentTab() {
+    closeIntervalForCurrentTab(preserveCurrentTab) {
         if (currentTab && timeIntervalList != undefined) {
             var item = timeIntervalList.find(o => o.url.isMatch(currentTab) && o.day == todayLocalDate());
             if (item != undefined)
                 item.closeInterval();
         }
-        currentTab = null;
+
+        if (!preserveCurrentTab) {
+            currentTab = null;
+        }
     }
 
     isNeedNotifyView(domain, tab){

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -49,7 +49,7 @@ function backgroundCheck() {
                     });
                 } else {
                     if (tab !== undefined) {
-                        if (currentTab == null || !tab.url.isHostMatch(currentTab.host)) {
+                        if (!tab.url.isMatch(currentTab)) {
                             activity.setCurrentActiveTab(tab.url);
                         }
                         chrome.idle.queryState(parseInt(setting_interval_inactivity), function(state) {
@@ -60,7 +60,7 @@ function backgroundCheck() {
                     }
                 }
             }
-        } else activity.closeIntervalForCurrentTab();
+        } else activity.closeIntervalForCurrentTab(true);
     });
 }
 

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -98,12 +98,13 @@ class UI {
         this.getTableOfSite().appendChild(document.createElement('hr'));
     }
 
-    setActiveTooltipe(currentTab) {
-        if (currentTab !== '') {
-            var element = document.getElementById(currentTab);
+    setActiveTooltip(currentTab) {
+        if (!!currentTab) {
+            const host = currentTab.host;
+            var element = document.getElementById(host);
             if (element !== null) {
                 var event = new Event("mouseenter");
-                document.getElementById(currentTab).dispatchEvent(event);
+                document.getElementById(host).dispatchEvent(event);
             }
         }
     }
@@ -197,7 +198,7 @@ class UI {
         var spanUrl = this.createElement('span', ['span-url'], tabUrlString);
         spanUrl.setAttribute('href', 'https://' + tabUrlString);
 
-        if (currentTab != null && tab.url.isHostMatch(currentTab.host)) {
+        if (tab.url.isMatch(currentTab)) {
             var divForImage = document.createElement('div');
             div.classList.add('span-active-url');
             var imgCurrentDomain = document.createElement('img');

--- a/src/scripts/webact.js
+++ b/src/scripts/webact.js
@@ -249,7 +249,7 @@ function getTabsFromStorage(tabs) {
   
       summaryCounter += counter;
   
-      const targetTab = tabGroup.tabs[0];
+      const targetTab = tabGroup.tabs.find(t => t.url.isMatch(currentTab)) || tabGroup.tabs[0];
   
       if (
         currentTypeOfList === TypeListEnum.ToDay ||
@@ -271,7 +271,7 @@ function getTabsFromStorage(tabs) {
     ui.addHrAfterTableOfSite();
     ui.createTotalBlock(totalTime, currentTypeOfList, summaryCounter);
     ui.drawChart(tabsForChart);
-    ui.setActiveTooltipe(currentTab);
+    ui.setActiveTooltip(currentTab);
   
     ui.removePreloader();
   }  
@@ -576,7 +576,7 @@ function getTabsFromStorageByDay(day, blockName) {
     for (const tabGroup of tabGroups){
         var summaryTime = tabGroup.summaryTime;
         var counter = tabGroup.counter;
-        const targetTab = tabGroup.tabs[0];
+        const targetTab = tabGroup.tabs.find(t => t.url.isMatch(currentTab)) || tabGroup.tabs[0];
 
         ui.addLineToTableOfSite(targetTab, currentTab, summaryTime, TypeListEnum.ByDays, counter, blockName + '_content');
     }


### PR DESCRIPTION
- Reverted tab match by host only and opted to try to find the active tab instead.
- `chrome.windows.getLastFocused` drops focus for the current window when the extension is opened to show the chart. This causes a race condition where the current tab is most likely cleared out by the time the chart is displayed. The fix is to allow preserving `currentTab` when closing the time interval.
- Removed `activity.clearCurrentActiveTab` as it is unused.
- Fixed additional issue with `setActiveTooltip` to correctly find tooltip by host.

![image](https://user-images.githubusercontent.com/1247613/136734916-956cb4a2-5351-44db-91bf-8fdfd259020e.png)
