### PR TITLE
[FEAT] Showcase time & counter for blocked website when deferring

### DIFF
--- a/src/block.html
+++ b/src/block.html
@@ -17,6 +17,10 @@
       <div class="description">You've reached your limit today on <span id="site" class="current-site"></span></div>
       <div class="description margin-top-10">Your current daily limit is <span id="limit" class="current-limit"></span></div>
 
+      <div class="description margin-top-10">You have already been here
+         <span id="deferredCount" class="deferred-metrics"></span> times for a total duration of
+         <span id="deferredTime" class="deferred-metrics"></span> today !
+      </div>
       <div class="margin-top-10"><a id="deffererBtn" class="defferer-link">Set aside for 5 minutes</a></div>
    </div>
    <p class="product-title">Web Activity Time Tracker</p>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -66,7 +66,7 @@ function backgroundCheck() {
 
 function mainTRacker(activeUrl, tab, activeTab) {
     if (activity.isLimitExceeded(activeUrl, tab) && !activity.wasDeferred(activeUrl)) {
-        setBlockPageToCurrent(activeTab.url, tab.summaryTime, tab.counter);
+        setBlockPageToCurrent(activeTab.url, tab.days.at(-1).summaryTime, tab.days.at(-1).counter);
     }
     if (!activity.isInBlackList(activeUrl)) {
         if (activity.isNeedNotifyView(activeUrl, tab)) {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -66,7 +66,7 @@ function backgroundCheck() {
 
 function mainTRacker(activeUrl, tab, activeTab) {
     if (activity.isLimitExceeded(activeUrl, tab) && !activity.wasDeferred(activeUrl)) {
-        setBlockPageToCurrent(activeTab.url, tab.days.at(-1).summaryTime, tab.days.at(-1).counter);
+        setBlockPageToCurrent(activeTab.url, tab.days.at(-1).summary, tab.days.at(-1).counter);
     }
     if (!activity.isInBlackList(activeUrl)) {
         if (activity.isNeedNotifyView(activeUrl, tab)) {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -66,7 +66,7 @@ function backgroundCheck() {
 
 function mainTRacker(activeUrl, tab, activeTab) {
     if (activity.isLimitExceeded(activeUrl, tab) && !activity.wasDeferred(activeUrl)) {
-        setBlockPageToCurrent(activeTab.url);
+        setBlockPageToCurrent(activeTab.url, tab.summaryTime, tab.counter);
     }
     if (!activity.isInBlackList(activeUrl)) {
         if (activity.isNeedNotifyView(activeUrl, tab)) {
@@ -131,8 +131,10 @@ function notificationAction(activeUrl, tab) {
         });
 }
 
-function setBlockPageToCurrent(currentUrl) {
-    var blockUrl = chrome.runtime.getURL("block.html") + '?url=' + currentUrl;
+function setBlockPageToCurrent(currentUrl, summaryTime, counter) {
+    var blockUrl = chrome.runtime.getURL("block.html") + '?url=' + currentUrl
+    + '&summaryTime=' + summaryTime
+    + '&counter=' + counter;
     chrome.tabs.query({ currentWindow: true, active: true }, function(tab) {
         chrome.tabs.update(tab.id, { url: blockUrl });
     });

--- a/src/scripts/block.js
+++ b/src/scripts/block.js
@@ -2,12 +2,18 @@
 
 var storage = new LocalStorage();
 var blockSiteUrl;
+var blockSiteTime;
+var blockSiteCounter;
 var restrictionList = [];
 
 document.addEventListener("DOMContentLoaded", function () {
   var url = new URL(document.URL);
   blockSiteUrl = url.searchParams.get("url");
+  blockSiteTime = url.searchParams.get("summaryTime");
+  blockSiteCounter = url.searchParams.get("counter");
   document.getElementById("site").innerText = extractHostname(blockSiteUrl);
+  document.getElementById("deferredTime").innerText = convertShortSummaryTimeToString(blockSiteTime);
+  document.getElementById("deferredCount").innerText = blockSiteCounter;
 
   storage.getValue(STORAGE_RESTRICTION_LIST, function (items) {
     restrictionList = items;

--- a/src/style/block.css
+++ b/src/style/block.css
@@ -42,3 +42,9 @@ body{
     text-decoration: underline;
     cursor: pointer;
 }
+
+.deferred-metrics{
+    font-weight: 500;
+    font-size: 1.2rem;
+    color: rgb(202, 48, 48);
+}


### PR DESCRIPTION
**Context -**
- I click `Set aside for 5 minutes` too much too often for blocked websites.
- Hence added a patch to showcase the time I have spent on this blocked website when I am about to click `Set aside for 5 minutes`
- Also showcase the counter for the number of times I have navigated to this page
- This is what the page looks like now

**Implementation -**
- I have passed the `timeSummary` and `counter` for the current page, when navigating to `block.html` from background script.
<img width="1402" alt="Screenshot 2023-01-15 at 3 37 41 PM" src="https://user-images.githubusercontent.com/22821480/212534814-dc913933-0c40-4b99-8ba4-880a5a02abc2.png">
