### PR TITLE
change block page url open from new tab to current

### DIFF
--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -81,7 +81,7 @@ async function deferring() {
     haveToShowDeffering.value
   ) {
     await defering(webSite.value, 5);
-    if (sourceUrl.value != '') window.open(sourceUrl.value);
+    if (sourceUrl.value != '') window.location.replace(sourceUrl.value);
   }
 }
 </script>


### PR DESCRIPTION
Why?
When it shows a 5m timer button on a blocked website, it opens a `new tab` which takes us to that website for 5m, but when we again go back to that previous `tab` it doesn't hide the button which allow us to repeatedly open the blocked website.

Fix:
I simply changed the opening method, now it will open it in `current tab` instead of `new tab`.
